### PR TITLE
Fix travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/samhstn/elm-time-format.svg?branch=master)](https://travis-ci.org/samhstn/elm-time-format)
+[![Build Status](https://travis-ci.org/samhstn/time-format.svg?branch=master)](https://travis-ci.org/samhstn/time-format)
 
 # Elm Time Format
 


### PR DESCRIPTION
Update travis badge to reference `samhstn/time-format` rather than `samhstn/elm-time-format`